### PR TITLE
fixup! feat(@angular-ru/common): add useInjector method for accessing…

### DIFF
--- a/packages/common/integration/tests/ivy/helpers/test-decorators.ts
+++ b/packages/common/integration/tests/ivy/helpers/test-decorators.ts
@@ -15,7 +15,9 @@ export function InjectTestService(): PropertyDecorator {
 export function InjectFeatureTestService(): PropertyDecorator {
     return <T extends typeof Object.prototype>(prototypeRef: T, propertyKey: string | symbol): void => {
         useInjector(prototypeRef.constructor, (injector: Injector, instance: Any): void => {
-            instance[propertyKey] = injector.get(FeatureTestService);
+            const service: FeatureTestService = injector.get(FeatureTestService);
+            service.callsCounter++;
+            instance[propertyKey] = service;
         });
     };
 }

--- a/packages/common/integration/tests/ivy/helpers/test-default.ts
+++ b/packages/common/integration/tests/ivy/helpers/test-default.ts
@@ -52,6 +52,8 @@ export class FeatureTestService {
     @InjectTestService()
     public testService!: TestService;
 
+    public callsCounter: number = 0;
+
     constructor(public ngZone: NgZone) {}
 }
 

--- a/packages/common/integration/tests/ivy/ivy-utils.spec.ts
+++ b/packages/common/integration/tests/ivy/ivy-utils.spec.ts
@@ -75,6 +75,7 @@ describe('[TEST]: Ivy utils', (): void => {
         expect(component.featureTestService.constructor).toBe(FeatureTestService);
         expect(component.featureTestService.testService.constructor).toBe(TestService);
         expect(component.featureTestService.testService.testField).toBe('test');
+        expect(component.featureTestService.callsCounter).toBe(1);
     });
 
     it('should work useInjector with component extending directive', async function (): Promise<void> {


### PR DESCRIPTION
… DI inside decorators & tests

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The factory wrapper generated (that emits all of the `effectFunction`s) by `useInjector` function was wrapped recursively again by the next decorator handler. This caused user's `effectFunction` to run the same number of times as the number of added decorators.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The factory wrapper generates only once, so `effectFunction`s are called normally.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
