### PR TITLE
fix(@angular-ru/ng-table-builder): fix sort-types input works only once

### DIFF
--- a/packages/ng-table-builder/integration/app/src/samples/sample-six/sample-six.component.html
+++ b/packages/ng-table-builder/integration/app/src/samples/sample-six/sample-six.component.html
@@ -2,6 +2,7 @@
     <span>
         Example sorting
 
+        <button mat-raised-button (click)="sortByIdDirection = !sortByIdDirection">Toggle sort by ID</button>
         <mat-checkbox class="regenerate" [(ngModel)]="skipSort" [ngModelOptions]="{ standalone: true }">
             Skip internal sort
         </mat-checkbox>
@@ -13,7 +14,7 @@
 <ngx-table-builder
     [source]="data"
     [skip-sort]="skipSort"
-    [sort-types]="{ id: 'desc' }"
+    [sort-types]="sortByIdDirection ? { id: 'asc' } : { id: 'desc' }"
     (sortChanges)="sortChanges($event)"
 >
     <ngx-empty>No data</ngx-empty>

--- a/packages/ng-table-builder/integration/app/src/samples/sample-six/sample-six.component.ts
+++ b/packages/ng-table-builder/integration/app/src/samples/sample-six/sample-six.component.ts
@@ -14,6 +14,7 @@ declare const hljs: Any;
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SampleSixComponent implements OnInit, AfterViewInit {
+    public sortByIdDirection: boolean = true;
     public data: TableRow[] = [];
     public skipSort: boolean = false;
     constructor(public readonly dialog: MatDialog, private readonly cd: ChangeDetectorRef) {}
@@ -43,7 +44,13 @@ export class SampleSixComponent implements OnInit, AfterViewInit {
             data: {
                 title: 'Overview sortable table',
                 description: '',
-                code: `<ngx-table-builder [source]="data"  [sort-types]="{ myKey: 'asc' }"></ngx-table-builder>`
+                code: `
+<ngx-table-builder
+    [source]="data"
+    [skip-sort]="skipSort"
+    [sort-types]="sortByIdDirection ? { id: 'asc' } : { id: 'desc' }"
+    (sortChanges)="sortChanges($event)"
+></ngx-table-builder>`
             },
             height: '350px',
             width: '700px'

--- a/packages/ng-table-builder/integration/tests/components/table-builder.component.spec.ts
+++ b/packages/ng-table-builder/integration/tests/components/table-builder.component.spec.ts
@@ -1,0 +1,72 @@
+import { Component, Injectable, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PlainObject } from '@angular-ru/common/typings';
+import { WebWorkerThreadService } from '@angular-ru/common/webworker';
+import { TableBuilderComponent, TableBuilderModule, TableRow } from '@angular-ru/ng-table-builder';
+
+@Component({
+    selector: 'app-ngx-table-builder-mock',
+    template: ` <ngx-table-builder [source]="data" [sort-types]="sortTypes"></ngx-table-builder>`
+})
+class NgxTableBuilderMockComponent {
+    @ViewChild(TableBuilderComponent, { static: true }) public tableBuilderComponent!: TableBuilderComponent;
+
+    public data: TableRow[] = [
+        { id: 1, name: 'Max', lastName: 'Ivanov' },
+        { id: 2, name: 'Ivan', lastName: 'Petrov' },
+        { id: 3, name: 'Petr', lastName: 'Sidorov' }
+    ];
+
+    public sortTypes: PlainObject | null = null;
+}
+
+@Injectable()
+class MockWebWorkerThreadService {
+    public run<T, K>(workerFunction: (input?: K) => T, data?: K): Promise<T> {
+        return Promise.resolve(workerFunction(data));
+    }
+}
+
+describe('[TEST] Table builder', (): void => {
+    let componentFixture: ComponentFixture<NgxTableBuilderMockComponent>;
+    let component: NgxTableBuilderMockComponent;
+
+    beforeEach((): void => {
+        TestBed.configureTestingModule({
+            declarations: [NgxTableBuilderMockComponent],
+            imports: [TableBuilderModule],
+            providers: [
+                {
+                    provide: WebWorkerThreadService,
+                    useClass: MockWebWorkerThreadService
+                }
+            ]
+        }).compileComponents();
+    });
+
+    beforeEach((): void => {
+        componentFixture = TestBed.createComponent(NgxTableBuilderMockComponent);
+        component = componentFixture.componentInstance;
+        componentFixture.autoDetectChanges();
+    });
+
+    it('should correct sort by input', (): void => {
+        const tableBuilderComponent: TableBuilderComponent = component.tableBuilderComponent;
+
+        component.sortTypes = { id: 'desc' };
+        componentFixture.detectChanges();
+        expect(tableBuilderComponent.source).toEqual([
+            { id: 3, name: 'Petr', lastName: 'Sidorov' },
+            { id: 2, name: 'Ivan', lastName: 'Petrov' },
+            { id: 1, name: 'Max', lastName: 'Ivanov' }
+        ]);
+
+        component.sortTypes = { name: 'asc' };
+        componentFixture.detectChanges();
+        expect(tableBuilderComponent.source).toEqual([
+            { id: 2, name: 'Ivan', lastName: 'Petrov' },
+            { id: 1, name: 'Max', lastName: 'Ivanov' },
+            { id: 3, name: 'Petr', lastName: 'Sidorov' }
+        ]);
+    });
+});

--- a/packages/ng-table-builder/src/interfaces/table-builder.internal.ts
+++ b/packages/ng-table-builder/src/interfaces/table-builder.internal.ts
@@ -1,6 +1,8 @@
 export const enum TableSimpleChanges {
     SOURCE_KEY = 'source',
-    SCHEMA_COLUMNS = 'schemaColumns'
+    SCHEMA_COLUMNS = 'schemaColumns',
+    SKIP_SORT = 'skipSort',
+    SORT_TYPES = 'sortTypes'
 }
 
 export interface DynamicHeightOptions {

--- a/packages/ng-table-builder/src/services/sortable/sortable.service.ts
+++ b/packages/ng-table-builder/src/services/sortable/sortable.service.ts
@@ -39,7 +39,7 @@ export class SortableService {
     }
 
     public setDefinition(definition: PlainObjectOf<string>): void {
-        this.definition = (this.empty ? definition || {} : this.definition) as PlainObjectOf<SortOrderType>;
+        this.definition = definition as PlainObjectOf<SortOrderType>;
     }
 
     public setSkipSort(skipInternalSort: boolean): void {
@@ -51,7 +51,7 @@ export class SortableService {
     }
 
     public updateSortKey(key: string): void {
-        this.definition = this.updateImmutableDefinitions(key);
+        this.setDefinition(this.updateDefinitionByKeyImmutably(key));
         this.triggerOnChanges();
     }
 
@@ -76,19 +76,20 @@ export class SortableService {
         });
     }
 
-    private updateImmutableDefinitions(key: string): PlainObjectOf<SortOrderType> {
-        const existKey: SortOrderType = this.definition[key];
+    private updateDefinitionByKeyImmutably(key: string): PlainObjectOf<SortOrderType> {
+        const definition: PlainObjectOf<SortOrderType> = { ...this.definition };
+        const existKey: SortOrderType = definition[key];
 
         if (existKey) {
             if (existKey === SortOrderType.ASC) {
-                this.definition[key] = SortOrderType.DESC;
+                definition[key] = SortOrderType.DESC;
             } else {
-                delete this.definition[key];
+                delete definition[key];
             }
         } else {
-            this.definition[key] = SortOrderType.ASC;
+            definition[key] = SortOrderType.ASC;
         }
 
-        return { ...this.definition };
+        return definition;
     }
 }

--- a/packages/ng-table-builder/src/table-builder.component.ts
+++ b/packages/ng-table-builder/src/table-builder.component.ts
@@ -159,12 +159,19 @@ export class TableBuilderComponent
         this.checkCorrectInitialSchema(changes);
 
         this.sourceIsNull = this.checkSourceIsNull();
-        this.setSortTypes();
+
+        if (TableSimpleChanges.SKIP_SORT in changes) {
+            this.sortable.setSkipSort(this.isSkippedInternalSort);
+        }
 
         if (this.nonIdenticalStructure) {
             this.preRenderTable();
         } else if (TableSimpleChanges.SOURCE_KEY in changes && this.isRendered) {
             this.preSortAndFilterTable(changes);
+        }
+
+        if (TableSimpleChanges.SORT_TYPES in changes) {
+            this.setSortTypes();
         }
     }
 
@@ -179,6 +186,7 @@ export class TableBuilderComponent
             this.selection.selectionModeIsEnabled = true;
             this.selection.setProducerDisableFn(this.produceDisableFn);
         }
+        this.sortable.setSortChanges(this.sortChanges);
     }
 
     public markVisibleColumn(column: HTMLDivElement, visible: boolean): void {
@@ -420,9 +428,9 @@ export class TableBuilderComponent
 
     private setSortTypes(): void {
         this.sortable.setDefinition({ ...this.sortTypes });
-        this.sortable.setSkipSort(this.isSkippedInternalSort);
-        this.sortable.setSortChanges(this.sortChanges);
-        this.sortTypes = {};
+        if (this.sourceExists) {
+            this.sortAndFilter().then((): void => this.reCheckDefinitions());
+        }
     }
 
     private listenColumnListChanges(): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
'sort-types' input works on ng-table-builder only once

Issue Number: N/A

## What is the new behavior?
'sort-types' input works continuously

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
