### PR TITLE
fix(@angular-ru/ng-table-builder): remove spread from mock generator

### DIFF
--- a/packages/ng-table-builder/integration/tests/helpers/utils/mocks-generator.ts
+++ b/packages/ng-table-builder/integration/tests/helpers/utils/mocks-generator.ts
@@ -29,9 +29,10 @@ export class MocksGenerator {
                                 const random = (min: number, max: number) => min + Math.random() * (max - min);
 
                                 if (cols > 6) {
-                                    baseRow['About Big Text And More Powerful Label Fugiat Tempor Sunt Nostrud'] = [
-                                        ...Array(Math.ceil(random(0, 1000)))
-                                    ]
+                                    baseRow[
+                                        'About Big Text And More Powerful Label Fugiat Tempor Sunt Nostrud'
+                                    ] = Array(Math.ceil(random(0, 1000)))
+                                        .fill(null)
                                         .map((): string => (~~(Math.random() * 36)).toString(36))
                                         .join('');
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the demo (table builder), an error occurs while loading pages that use the MocksGenerator.

<img width="618" alt="Снимок экрана 2021-05-09 в 15 54 45" src="https://user-images.githubusercontent.com/33288503/117573118-e409ae00-b0de-11eb-917a-7a7c2291bc1e.png">

In the function, which is allocated for a separate web worker, the spread-operator is used, which after # 573 began to be converted into `tslib__WEBPACK_IMPORTED_MODULE_0 __ [" __ spread "]`. Since objects are not imported into the worker, an error is thrown: `Uncaught ReferenceError: tslib__WEBPACK_IMPORTED_MODULE_0__ is not defined`.

<img width="1201" alt="Снимок экрана 2021-05-09 в 15 56 06" src="https://user-images.githubusercontent.com/33288503/117573146-11eef280-b0df-11eb-95ef-4e057ce193b7.png">

As a quick workaround, I propose to get rid of the spread-operator for now and think about how to throw the necessary entities to the worker.

Issue Number: N/A

## What is the new behavior?

Everything is ok.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
