### PR TITLE
fix(@angular-ru/ng-table-builder): fix selectedItems pipe

### DIFF
--- a/packages/ng-table-builder/integration/tests/samples/lifecycle/lifecycle.spec.ts
+++ b/packages/ng-table-builder/integration/tests/samples/lifecycle/lifecycle.spec.ts
@@ -1,9 +1,10 @@
+import { ApplicationRef, ChangeDetectorRef, ElementRef, NgZone, QueryList, SimpleChanges } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { Any, Fn, PlainObject } from '@angular-ru/common/typings';
 import { WebWorkerThreadService } from '@angular-ru/common/webworker';
 import { NgxColumnComponent, NgxTableViewChangesService, TableBuilderComponent } from '@angular-ru/ng-table-builder';
-import { ApplicationRef, ChangeDetectorRef, ElementRef, NgZone, QueryList, SimpleChanges } from '@angular/core';
 
-import { fakeAsync, tick } from '@angular/core/testing';
+import { TableSelectedItemsPipe } from '../../../../src/pipes/table-selected-items.pipe';
 import { ContextMenuService } from '../../../../src/services/context-menu/context-menu.service';
 import { DraggableService } from '../../../../src/services/draggable/draggable.service';
 import { FilterableService } from '../../../../src/services/filterable/filterable.service';
@@ -11,7 +12,6 @@ import { ResizableService } from '../../../../src/services/resizer/resizable.ser
 import { SelectionService } from '../../../../src/services/selection/selection.service';
 import { SortableService } from '../../../../src/services/sortable/sortable.service';
 import { TemplateParserService } from '../../../../src/services/template-parser/template-parser.service';
-import { TableSelectedItemsPipe } from '../../../../src/pipes/table-selected-items.pipe';
 
 describe('[TEST]: Lifecycle table', () => {
     let table: TableBuilderComponent<PlainObject>;
@@ -29,6 +29,11 @@ describe('[TEST]: Lifecycle table', () => {
     const mockNgZone: Partial<NgZone> = {
         run: (callback: Fn): Any => callback(),
         runOutsideAngular: (callback: Fn): Any => callback()
+    };
+    const webWorker: Partial<WebWorkerThreadService> = {
+        run<T, K>(workerFunction: (input: K) => T, data?: K): Promise<T> {
+            return Promise.resolve(workerFunction(data!));
+        }
     };
 
     interface PeriodicElement {
@@ -53,7 +58,7 @@ describe('[TEST]: Lifecycle table', () => {
     ];
 
     beforeEach(() => {
-        const worker: WebWorkerThreadService = new WebWorkerThreadService();
+        const worker: WebWorkerThreadService = webWorker as WebWorkerThreadService;
         const zone: NgZone = mockNgZone as NgZone;
         const app: ApplicationRef = appRef as ApplicationRef;
         const view: NgxTableViewChangesService = new NgxTableViewChangesService();
@@ -114,18 +119,36 @@ describe('[TEST]: Lifecycle table', () => {
         table.columnList = new QueryList<ElementRef<HTMLDivElement>>();
     });
 
-    it('should be basic api', () => {
-        table.source = JSON.parse(JSON.stringify(data));
+    it('should be basic api', async () => {
+        table.setSource(JSON.parse(JSON.stringify(data)));
 
-        expect(new TableSelectedItemsPipe(table).transform({})).toEqual([]);
-        expect(new TableSelectedItemsPipe(table).transform({ 1: true })).toEqual([
-            {
-                name: 'Hydrogen',
-                position: 1,
-                symbol: 'H',
-                weight: 1.0079
-            }
+        expect(new TableSelectedItemsPipe(table).transform({ 1: true, 2: true })).toEqual([
+            { position: 1, name: 'Hydrogen', symbol: 'H', weight: 1.0079 },
+            { position: 2, name: 'Helium', weight: 4.0026, symbol: 'He' }
         ]);
+
+        // enable and check filter
+        table.enableFiltering = true;
+        table.filterable.filterValue = 'Hydrogen';
+        table.filterable.filterType = 'START_WITH';
+        await table.sortAndFilter();
+
+        expect(table.source).toEqual([{ name: 'Hydrogen', position: 1, symbol: 'H', weight: 1.0079 }]);
+
+        // expect selection pipe works even with filtered values
+        expect(new TableSelectedItemsPipe(table).transform({})).toEqual([]);
+        expect(new TableSelectedItemsPipe(table).transform({ 1: true, 2: true })).toEqual([
+            { position: 1, name: 'Hydrogen', symbol: 'H', weight: 1.0079 },
+            { position: 2, name: 'Helium', weight: 4.0026, symbol: 'He' }
+        ]);
+
+        expect(table.lastItem).toEqual({ position: 1, name: 'Hydrogen', symbol: 'H', weight: 1.0079 });
+
+        // disable filter
+        table.enableFiltering = true;
+        table.filterable.filterValue = null;
+        table.filterable.filterType = null;
+        await table.sortAndFilter();
 
         expect(table.lastItem).toEqual({ position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne' });
     });

--- a/packages/ng-table-builder/integration/tests/samples/lifecycle/lifecycle.spec.ts
+++ b/packages/ng-table-builder/integration/tests/samples/lifecycle/lifecycle.spec.ts
@@ -1,5 +1,6 @@
 import { ApplicationRef, ChangeDetectorRef, ElementRef, NgZone, QueryList, SimpleChanges } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { deepClone } from '@angular-ru/common/object';
 import { Any, Fn, PlainObject } from '@angular-ru/common/typings';
 import { WebWorkerThreadService } from '@angular-ru/common/webworker';
 import { NgxColumnComponent, NgxTableViewChangesService, TableBuilderComponent } from '@angular-ru/ng-table-builder';
@@ -120,7 +121,7 @@ describe('[TEST]: Lifecycle table', () => {
     });
 
     it('should be basic api', async () => {
-        table.setSource(JSON.parse(JSON.stringify(data)));
+        table.setSource(deepClone(data));
 
         expect(new TableSelectedItemsPipe(table).transform({ 1: true, 2: true })).toEqual([
             { position: 1, name: 'Hydrogen', symbol: 'H', weight: 1.0079 },
@@ -132,7 +133,6 @@ describe('[TEST]: Lifecycle table', () => {
         table.filterable.filterValue = 'Hydrogen';
         table.filterable.filterType = 'START_WITH';
         await table.sortAndFilter();
-
         expect(table.source).toEqual([{ name: 'Hydrogen', position: 1, symbol: 'H', weight: 1.0079 }]);
 
         // expect selection pipe works even with filtered values
@@ -144,17 +144,18 @@ describe('[TEST]: Lifecycle table', () => {
 
         expect(table.lastItem).toEqual({ position: 1, name: 'Hydrogen', symbol: 'H', weight: 1.0079 });
 
-        // disable filter
+        // reset filter
         table.enableFiltering = true;
         table.filterable.filterValue = null;
         table.filterable.filterType = null;
         await table.sortAndFilter();
+        expect(table.source).toEqual(data);
 
         expect(table.lastItem).toEqual({ position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne' });
     });
 
     it('should be unchecked state before ngOnChange', () => {
-        table.source = JSON.parse(JSON.stringify(data));
+        table.source = deepClone(data);
 
         expect(table.isRendered).toEqual(false);
         expect(table.modelColumnKeys).toEqual([]);
@@ -167,7 +168,7 @@ describe('[TEST]: Lifecycle table', () => {
     });
 
     it('should be correct generate modelColumnKeys after ngOnChange', () => {
-        table.source = JSON.parse(JSON.stringify(data));
+        table.source = deepClone(data);
         table.enableSelection = true;
         table.ngOnChanges(changes);
         table.ngOnInit();
@@ -201,7 +202,7 @@ describe('[TEST]: Lifecycle table', () => {
     });
 
     it('should be correct state after ngAfterContentInit', fakeAsync(() => {
-        table.source = JSON.parse(JSON.stringify(data));
+        table.source = deepClone(data);
         table.ngOnChanges(changes);
         table.ngOnInit();
         table.ngAfterContentInit();
@@ -247,7 +248,7 @@ describe('[TEST]: Lifecycle table', () => {
         expect(table.contentCheck).toEqual(false);
         expect(table.sourceExists).toEqual(false);
 
-        table.source = JSON.parse(JSON.stringify(data));
+        table.source = deepClone(data);
         templates.reset([new NgxColumnComponent()]);
         templates.notifyOnChanges();
 
@@ -271,7 +272,7 @@ describe('[TEST]: Lifecycle table', () => {
     it('should be correct template changes with check renderCount', fakeAsync(() => {
         const templates: QueryList<NgxColumnComponent<PlainObject>> = new QueryList();
         table.columnTemplates = templates;
-        table.source = JSON.parse(JSON.stringify(data));
+        table.source = deepClone(data);
 
         table.ngOnChanges(changes);
         table.ngOnInit();
@@ -291,7 +292,7 @@ describe('[TEST]: Lifecycle table', () => {
         expect(table.contentCheck).toEqual(false);
         expect(table.sourceExists).toEqual(true);
 
-        table.source = JSON.parse(JSON.stringify(data));
+        table.source = deepClone(data);
         templates.reset([new NgxColumnComponent()]);
 
         templates.notifyOnChanges();
@@ -330,7 +331,7 @@ describe('[TEST]: Lifecycle table', () => {
         templates.reset([new NgxColumnComponent()]);
         templates.notifyOnChanges();
 
-        table.source = JSON.parse(JSON.stringify(data));
+        table.source = deepClone(data);
         table.ngOnChanges(changes);
 
         tick(1000);
@@ -372,7 +373,7 @@ describe('[TEST]: Lifecycle table', () => {
     });
 
     it('should be correct sync rendering', fakeAsync(() => {
-        table.source = JSON.parse(JSON.stringify(data));
+        table.source = deepClone(data);
 
         table.ngOnChanges(changes);
         table.renderTable();

--- a/packages/ng-table-builder/src/abstract-table-builder-api.directive.ts
+++ b/packages/ng-table-builder/src/abstract-table-builder-api.directive.ts
@@ -239,6 +239,10 @@ export abstract class AbstractTableBuilderApiDirective<T>
         return this.source && this.source.length ? this.source : [];
     }
 
+    public get originalSourceRef(): T[] {
+        return this.originalSource ?? this.source ?? [];
+    }
+
     public get isEnableFiltering(): boolean {
         return this.enableFiltering !== false;
     }

--- a/packages/ng-table-builder/src/abstract-table-builder-api.directive.ts
+++ b/packages/ng-table-builder/src/abstract-table-builder-api.directive.ts
@@ -235,10 +235,16 @@ export abstract class AbstractTableBuilderApiDirective<T>
         return this.sourceRef.length;
     }
 
+    /**
+     * @description Returns a list of displayed table entries, including filters and sorting.
+     */
     public get sourceRef(): T[] {
-        return this.source && this.source.length ? this.source : [];
+        return this.source ?? [];
     }
 
+    /**
+     * @description Returns the entire list of table entries, excluding filters and sorting.
+     */
     public get originalSourceRef(): T[] {
         return this.originalSource ?? this.source ?? [];
     }

--- a/packages/ng-table-builder/src/pipes/table-selected-items.pipe.ts
+++ b/packages/ng-table-builder/src/pipes/table-selected-items.pipe.ts
@@ -9,6 +9,8 @@ export class TableSelectedItemsPipe<T> implements PipeTransform {
 
     public transform(selectedEntries?: PlainObjectOf<boolean>): T[] {
         const entries: PlainObjectOf<boolean> = selectedEntries ?? this.table.selectionEntries;
-        return this.table.sourceRef.filter((item: T): boolean => !!entries[(item as Any)[this.table.primaryKey]]);
+        return this.table.originalSourceRef.filter(
+            (item: T): boolean => !!entries[(item as Any)[this.table.primaryKey]]
+        );
     }
 }


### PR DESCRIPTION
turn selectedItems pipe to base on originalSource

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`tableSelectedItems` pipe returns item list in context of filter, so there no way to get all of selected items while filter is working.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

`tableSelectedItems` pipe returns item list based on `originalSource`, so there's no relations to filter.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
