### PR TITLE
fix(cdk): unexpected `&nbsp;` after marking & refactor

### DIFF
--- a/packages/cdk/integration/tests/jest/pipes/mark-by-filter-pipe.spec.ts
+++ b/packages/cdk/integration/tests/jest/pipes/mark-by-filter-pipe.spec.ts
@@ -13,11 +13,11 @@ describe('mark by filter pipe', () => {
         expect(pipe.transform('hello world')).toBe('hello world');
 
         expect(pipe.transform('hello world', 'world')).toEqual({
-            changingThisBreaksApplicationSecurity: 'hello&nbsp;<span style="background: #ffdd2d">world</span>'
+            changingThisBreaksApplicationSecurity: 'hello <span style="background: #ffdd2d">world</span>'
         });
 
         expect(pipe.transform('hello world', 'world', '#c3c3c3')).toEqual({
-            changingThisBreaksApplicationSecurity: 'hello&nbsp;<span style="background: #c3c3c3">world</span>'
+            changingThisBreaksApplicationSecurity: 'hello <span style="background: #c3c3c3">world</span>'
         });
     });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Search by 'n', or 'b', or 's', or 'p' then non-breaking space symbol unexpectedly appears in the result string

![image](https://user-images.githubusercontent.com/51880015/146755263-3f7b8e7a-fd4a-4f23-bbe6-1503dff66585.png)

## What is the new behavior?

Non-breaking space symbol does not appear anymore

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
