### PR TITLE
fix: non-disappearing tooltip

### DIFF
--- a/libs/cdk/virtual-table/src/components/table-cell/table-cell.component.ts
+++ b/libs/cdk/virtual-table/src/components/table-cell/table-cell.component.ts
@@ -74,10 +74,11 @@ export class TableCellComponent<T> implements OnDestroy {
     }
 
     public mouseLeaveCell(): void {
-        if (this.disableTooltip) {
+        if (isTrue(this.columnSchema?.overflowTooltip)) {
             return;
         }
 
+        this.removeElement();
         window.clearInterval(this.timeoutShowedFrameId ?? 0);
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
In some cases, we may end up with a "stuck" or "stuck and empty" tooltip.
For example: if we have a wide cell, due to the timeout for the appearance of the tooltip, it is possible to move the cursor to the side within this cell. In this case, the subscription to the "mouseleave" event with the tooltip element will not work, because the tooltip does not initially appear under the current cursor coordinates. 
If you move the cursor to another cell in this state, you can get an empty tooltip without content.

Moving the cursor within the cell:

<img width="1215" alt="Screenshot 2022-07-22 at 13 01 41" src="https://user-images.githubusercontent.com/35763219/180419656-d7cff443-11ee-4993-acac-92e6f5b1ccb5.png">

Scrolling after that:

<img width="1184" alt="Screenshot 2022-07-22 at 13 01 13" src="https://user-images.githubusercontent.com/35763219/180419684-650fe861-e876-4ca6-84e0-c2f13da95c1d.png">

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
At the mouseleave event on a cell element, a method call was added that removes the current tooltip.
Also, for these purposes, the check for executing logic when the mouseleave event is triggered was changed. In the case of a scroll, the event is also executed.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
