### PR TITLE
fix: changed icon rotation for ascending and descending sorting

### DIFF
--- a/libs/cdk/virtual-table/src/styles/columns.scss
+++ b/libs/cdk/virtual-table/src/styles/columns.scss
@@ -128,11 +128,11 @@
                 }
 
                 &__asc {
-                    transform: rotate(180deg);
+                    transform: rotate(0deg);
                 }
 
                 &__desc {
-                    transform: rotate(0deg);
+                    transform: rotate(180deg);
                 }
 
                 &-number {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Sort "Ascending" - the icon displays the actual descending.
Sort "Descending" - the icon displays the actual ascending.

Issue Number: N/A

## What is the new behavior?

<img width="224" alt="Screenshot 2022-09-14 at 17 41 28" src="https://user-images.githubusercontent.com/35763219/190186371-68437e40-f7ae-453c-a473-e8a7fbc550b7.png">
<img width="217" alt="Screenshot 2022-09-14 at 17 41 53" src="https://user-images.githubusercontent.com/35763219/190186381-1832f807-ac2b-41ce-ab15-13294783e741.png">


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
