### PR TITLE
fix: fix worksheet name in excel builder service

### DIFF
--- a/libs/cdk/excel/src/excel-builder.service.ts
+++ b/libs/cdk/excel/src/excel-builder.service.ts
@@ -133,8 +133,17 @@ export class ExcelBuilderService {
                         const xmlColumns: string = this.generateColumnsDescriptor(worksheet);
                         const xmlBodyRows: string = this.generateBodyRows(worksheet.flatEntries);
 
+                        const MAX_WORKSHEET_NAME_LENGTH: number = 31;
+                        const DEFAULT_WORKSHEET_NAME: string = 'Table';
+                        let worksheetName: string =
+                            worksheet.worksheetName?.match(/[\p{Alpha}\p{Nd}]+/gu)?.join(' ') ?? DEFAULT_WORKSHEET_NAME;
+
+                        if (worksheetName.length > MAX_WORKSHEET_NAME_LENGTH) {
+                            worksheetName = worksheetName.replace(/\s/g, '').slice(0, MAX_WORKSHEET_NAME_LENGTH);
+                        }
+
                         return `
-                        <Worksheet ss:Name="${worksheet.worksheetName}">
+                        <Worksheet ss:Name="${worksheetName}">
                             <Table ss:DefaultColumnWidth="${minColumnWidth}" ss:DefaultRowHeight="${rowHeight}">
                                 ${xmlColumns}
                                 ${xmlBodyRows}


### PR DESCRIPTION
## PR Checklist

-   [ x ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Special symbols in worksheet name of generated excel table did not allow it to open.

Issue Number: RPS-15376

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
