### PR TITLE
fix: move const to inside in filter worker function

### DIFF
--- a/libs/cdk/virtual-table/src/services/filterable/filter.worker.ts
+++ b/libs/cdk/virtual-table/src/services/filterable/filter.worker.ts
@@ -13,11 +13,10 @@ type NumericFilterTypes =
 
 type PlainValue = string | number | boolean;
 
-const INTERVAL_ARRAY_SIZE: number = 2;
-
 // TODO: should be refactor because duplicate code as sortWorker
 // eslint-disable-next-line sonarjs/cognitive-complexity,max-lines-per-function
 export function filterAllWorker<T>({ source, global, types, columns }: FilterableMessage<T>): T[] {
+    const INTERVAL_ARRAY_SIZE: number = 2;
     const { value: globalOperand, type: globalFilterType }: FilterGlobalOptions = global;
     let result: T[] = source;
 


### PR DESCRIPTION
When const is outside it's not imported in worker-thread service

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
