### PR TITLE
fix: send next message in websocket client synchronously bypass requestAnimationFrame

### DIFF
--- a/libs/cdk/websocket/src/services/abstract-websocket.client.ts
+++ b/libs/cdk/websocket/src/services/abstract-websocket.client.ts
@@ -133,9 +133,7 @@ export abstract class AbstractWebsocketClient<K extends string | PlainObject>
     private _connect(): void {
         this.socket$ = webSocket(this.webSocketSubjectConfig);
         this.socketSubscription = this.socket$.pipe(takeUntil(this.destroy$)).subscribe({
-            next: (message: WebsocketMessage<K, any>): void => {
-                window.requestAnimationFrame((): void => this.messages$.next(message));
-            },
+            next: (message: WebsocketMessage<K, any>): void => this.messages$.next(message),
             error: (): void => this.reconnect()
         });
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```
