### PR TITLE
fix: make selection in table work on command key on Mac

### DIFF
--- a/libs/cdk/tests/utils/utils.spec.ts
+++ b/libs/cdk/tests/utils/utils.spec.ts
@@ -15,6 +15,7 @@ import {
     fallbackIfEmpty,
     isBoolean,
     isIE,
+    isMacOS,
     isNil,
     isNotNil,
     parseXmlFromString,
@@ -130,6 +131,11 @@ describe('[TEST]: Common utils', () => {
 
     it('checkSomeValueIsEmpty should return true for a set of empty values', () =>
         expect(checkSomeValueIsEmpty('', undefined, null)).toBe(true));
+
+    it('isMacOS should return true if user agent shows that user has MacOS and false if otherwise', () => {
+        expect(isMacOS({ userAgent: `Mac` } as unknown as Navigator)).toBeTruthy();
+        expect(isMacOS({ userAgent: `Linux` } as unknown as Navigator)).toBeFalsy();
+    });
 
     describe('[TEST]: checkSomeValueIsTrue', () => {
         it('should return true if any item has value: "true"', () => {

--- a/libs/cdk/utils/src/is-mac-os.ts
+++ b/libs/cdk/utils/src/is-mac-os.ts
@@ -1,0 +1,3 @@
+export function isMacOS(navigatorRef: Navigator = navigator): boolean {
+    return navigatorRef.userAgent.includes('Mac');
+}

--- a/libs/cdk/utils/src/public_api.ts
+++ b/libs/cdk/utils/src/public_api.ts
@@ -23,6 +23,7 @@ export { isBoolean } from './is-boolean';
 export { isFalse } from './is-false';
 export { isFalsy } from './is-falsy';
 export { isIE } from './is-ie';
+export { isMacOS } from './is-mac-os';
 export { isNil } from './is-nil';
 export { isNotNil } from './is-not-nil';
 export { isTrue } from './is-true';

--- a/libs/cdk/virtual-table/src/services/selection/selection.service.ts
+++ b/libs/cdk/virtual-table/src/services/selection/selection.service.ts
@@ -3,6 +3,7 @@ import { Fn, Nullable, PlainObjectOf, PrimaryKey } from '@angular-ru/cdk/typings
 import { checkValueIsEmpty, isNil } from '@angular-ru/cdk/utils';
 import { Subject } from 'rxjs';
 
+import { isMacOS } from '../../../../utils/src/is-mac-os';
 import { ProduceDisableFn } from '../../interfaces/table-builder.external';
 import { KeyType, RowId, SelectionStatus } from '../../interfaces/table-builder.internal';
 import { SelectionMap } from './selection';
@@ -92,14 +93,14 @@ export class SelectionService<T> implements OnDestroy {
         }
 
         const rows: T[] = this.rows ?? [];
-        const { shiftKey, ctrlKey }: MouseEvent = event;
+        const { shiftKey, ctrlKey, metaKey }: MouseEvent = event;
         const index: number = rows.findIndex(
             (item: T): boolean => ((item as any) ?? ({} as T))[this.primaryKey] === (row ?? {})[this.primaryKey]
         );
 
         if (shiftKey) {
             this.multipleSelectByShiftKeydown(index);
-        } else if (ctrlKey) {
+        } else if (isMacOS() ? metaKey : ctrlKey) {
             this.multipleSelectByCtrlKeydown(row, index);
         } else {
             this.singleSelect(row, index);

--- a/libs/cdk/virtual-table/src/services/selection/selection.service.ts
+++ b/libs/cdk/virtual-table/src/services/selection/selection.service.ts
@@ -1,9 +1,8 @@
 import { Injectable, NgZone, OnDestroy } from '@angular/core';
 import { Fn, Nullable, PlainObjectOf, PrimaryKey } from '@angular-ru/cdk/typings';
-import { checkValueIsEmpty, isNil } from '@angular-ru/cdk/utils';
+import { checkValueIsEmpty, isMacOS, isNil } from '@angular-ru/cdk/utils';
 import { Subject } from 'rxjs';
 
-import { isMacOS } from '../../../../utils/src/is-mac-os';
 import { ProduceDisableFn } from '../../interfaces/table-builder.external';
 import { KeyType, RowId, SelectionStatus } from '../../interfaces/table-builder.internal';
 import { SelectionMap } from './selection';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Selecting table rows on Mac OS using control + click causes unexpected appearance of context menu. 

Issue Number: N/A

## What is the new behavior?
It is possible now to select rows with command + click, and context menu does not appear as a result of selection.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
