### PR TITLE
feat: make it possible to use column headers with dots

### DIFF
--- a/libs/cdk/virtual-table/src/abstract-table-builder-api.directive.ts
+++ b/libs/cdk/virtual-table/src/abstract-table-builder-api.directive.ts
@@ -102,6 +102,7 @@ export abstract class AbstractTableBuilderApiDirective<T>
     @Input('vertical-border') public verticalBorder: boolean = true;
     @Input('enable-selection') public enableSelection: boolean | string = false;
     @Input('enable-filtering') public enableFiltering: boolean | string = false;
+    @Input('disable-deep-path') public disableDeepPath: boolean = false;
     @Input('produce-disable-fn') public produceDisableFn: ProduceDisableFn<T> = null;
     @Input('row-css-classes') public rowCssClasses: PlainObjectOf<string[]> = {};
     @Input('schema-columns') public schemaColumns: Nullable<TableUpdateSchema> = null;

--- a/libs/cdk/virtual-table/src/components/table-cell/table-cell.component.html
+++ b/libs/cdk/virtual-table/src/components/table-cell/table-cell.component.html
@@ -14,8 +14,8 @@
                 $implicit:
                     columnSchema?.td?.context === contextType.CELL
                         ? columnSchema?.td?.useDeepPath && !disableDeepPath
-                            ? (item | deepPath: columnSchema?.key:columnSchema?.stub)
-                            : (item![$castKey(columnSchema?.key)] | defaultValue: columnSchema?.stub)
+                            ? (item | deepPath : columnSchema?.key : columnSchema?.stub)
+                            : (item![$castKey(columnSchema?.key)] | defaultValue : columnSchema?.stub)
                         : item
             }"
         ></ng-template>
@@ -30,16 +30,16 @@
                 [key]="columnSchema?.key"
                 [text]="
                     columnSchema?.td?.useDeepPath && !disableDeepPath
-                        ? (item | deepPath: columnSchema?.key:columnSchema?.stub)
-                        : (item![$castKey(columnSchema?.key)] | defaultValue: columnSchema?.stub)
+                        ? (item | deepPath : columnSchema?.key : columnSchema?.stub)
+                        : (item![$castKey(columnSchema?.key)] | defaultValue : columnSchema?.stub)
                 "
             ></ngx-filter-viewer>
         </ng-template>
         <ng-template #simple>
             {{
                 columnSchema?.td?.useDeepPath && !disableDeepPath
-                    ? (item | deepPath: columnSchema?.key:columnSchema?.stub)
-                    : (item![$castKey(columnSchema?.key)] | defaultValue: columnSchema?.stub)
+                    ? (item | deepPath : columnSchema?.key : columnSchema?.stub)
+                    : (item![$castKey(columnSchema?.key)] | defaultValue : columnSchema?.stub)
             }}
         </ng-template>
     </ng-template>

--- a/libs/cdk/virtual-table/src/components/table-cell/table-cell.component.html
+++ b/libs/cdk/virtual-table/src/components/table-cell/table-cell.component.html
@@ -13,9 +13,9 @@
             [ngTemplateOutletContext]="{
                 $implicit:
                     columnSchema?.td?.context === contextType.CELL
-                        ? columnSchema?.td?.useDeepPath
-                            ? (item | deepPath : columnSchema?.key : columnSchema?.stub)
-                            : (item![$castKey(columnSchema?.key)] | defaultValue : columnSchema?.stub)
+                        ? columnSchema?.td?.useDeepPath && !disableDeepPath
+                            ? (item | deepPath: columnSchema?.key:columnSchema?.stub)
+                            : (item![$castKey(columnSchema?.key)] | defaultValue: columnSchema?.stub)
                         : item
             }"
         ></ng-template>
@@ -29,17 +29,17 @@
                 [index]="index"
                 [key]="columnSchema?.key"
                 [text]="
-                    columnSchema?.td?.useDeepPath
-                        ? (item | deepPath : columnSchema?.key : columnSchema?.stub)
-                        : (item![$castKey(columnSchema?.key)] | defaultValue : columnSchema?.stub)
+                    columnSchema?.td?.useDeepPath && !disableDeepPath
+                        ? (item | deepPath: columnSchema?.key:columnSchema?.stub)
+                        : (item![$castKey(columnSchema?.key)] | defaultValue: columnSchema?.stub)
                 "
             ></ngx-filter-viewer>
         </ng-template>
         <ng-template #simple>
             {{
-                columnSchema?.td?.useDeepPath
-                    ? (item | deepPath : columnSchema?.key : columnSchema?.stub)
-                    : (item![$castKey(columnSchema?.key)] | defaultValue : columnSchema?.stub)
+                columnSchema?.td?.useDeepPath && !disableDeepPath
+                    ? (item | deepPath: columnSchema?.key:columnSchema?.stub)
+                    : (item![$castKey(columnSchema?.key)] | defaultValue: columnSchema?.stub)
             }}
         </ng-template>
     </ng-template>

--- a/libs/cdk/virtual-table/src/components/table-cell/table-cell.component.ts
+++ b/libs/cdk/virtual-table/src/components/table-cell/table-cell.component.ts
@@ -42,6 +42,7 @@ export class TableCellComponent<T> implements OnDestroy {
     @Input('column-schema') public columnSchema: Nullable<ColumnsSchema> = null;
     @Input('enable-filtering') public enableFiltering: boolean = false;
     @Input('viewport-info') public viewportInfo: Nullable<ViewPortInfo> = null;
+    @Input('disable-deep-path') public disableDeepPath: boolean = false;
     public contextType: typeof ImplicitContext = ImplicitContext;
 
     constructor(public readonly cd: ChangeDetectorRef, private readonly ngZone: NgZone) {}

--- a/libs/cdk/virtual-table/src/components/table-tbody/table-tbody.component.html
+++ b/libs/cdk/virtual-table/src/components/table-tbody/table-tbody.component.html
@@ -14,7 +14,7 @@
             *ngIf="item"
             #parent
             class="table-grid__cell table-grid__cell--body"
-            [ngClass]="columnSchema?.td?.class | mergeCssClasses: rowCssClasses[item[primaryKey!]]"
+            [ngClass]="columnSchema?.td?.class | mergeCssClasses : rowCssClasses[item[primaryKey!]]"
             [ngStyle]="columnSchema?.td?.style || []"
             [style.transform]="'translateY(' + virtualIndex.offsetTop + 'px)'"
             [style.min-height.px]="columnSchema?.td?.height || clientRowHeight"
@@ -25,7 +25,7 @@
             [class.table-grid__cell--enable-selection]="enableSelection"
             [class.table-grid__cell--selected]="selectionEntries[item[primaryKey!]]"
             [class.table-grid__cell--text-bold]="columnSchema?.td?.textBold"
-            [class.table-grid__cell--disable]="item | disableRow: produceDisableFn"
+            [class.table-grid__cell--disable]="item | disableRow : produceDisableFn"
             (selectstart)="(canSelectTextInTable)"
             (contextmenu)="openContextMenu($event, columnSchema?.key, item)"
             (click)="handleOnClick(item, columnSchema?.key!, $event, columnSchema?.td?.onClick)"

--- a/libs/cdk/virtual-table/src/components/table-tbody/table-tbody.component.html
+++ b/libs/cdk/virtual-table/src/components/table-tbody/table-tbody.component.html
@@ -14,7 +14,7 @@
             *ngIf="item"
             #parent
             class="table-grid__cell table-grid__cell--body"
-            [ngClass]="columnSchema?.td?.class | mergeCssClasses : rowCssClasses[item[primaryKey!]]"
+            [ngClass]="columnSchema?.td?.class | mergeCssClasses: rowCssClasses[item[primaryKey!]]"
             [ngStyle]="columnSchema?.td?.style || []"
             [style.transform]="'translateY(' + virtualIndex.offsetTop + 'px)'"
             [style.min-height.px]="columnSchema?.td?.height || clientRowHeight"
@@ -25,7 +25,7 @@
             [class.table-grid__cell--enable-selection]="enableSelection"
             [class.table-grid__cell--selected]="selectionEntries[item[primaryKey!]]"
             [class.table-grid__cell--text-bold]="columnSchema?.td?.textBold"
-            [class.table-grid__cell--disable]="item | disableRow : produceDisableFn"
+            [class.table-grid__cell--disable]="item | disableRow: produceDisableFn"
             (selectstart)="(canSelectTextInTable)"
             (contextmenu)="openContextMenu($event, columnSchema?.key, item)"
             (click)="handleOnClick(item, columnSchema?.key!, $event, columnSchema?.td?.onClick)"
@@ -43,6 +43,7 @@
                     [column-schema]="columnSchema"
                     [enable-filtering]="enableFiltering"
                     [is-filterable]="columnSchema?.filterable!"
+                    [disable-deep-path]="disableDeepPath"
                 ></table-cell>
             </div>
         </div>

--- a/libs/cdk/virtual-table/src/components/table-tbody/table-tbody.component.ts
+++ b/libs/cdk/virtual-table/src/components/table-tbody/table-tbody.component.ts
@@ -49,6 +49,7 @@ export class TableTbodyComponent<T> {
     @Input('virtual-indexes') public virtualIndexes: VirtualIndex[] = [];
     @Input('enable-selection') public enableSelection: boolean = false;
     @Input('enable-filtering') public enableFiltering: boolean = false;
+    @Input('disable-deep-path') public disableDeepPath: boolean = false;
     @Input('table-viewport') public tableViewport: Nullable<HTMLElement> = null;
     @Input('column-virtual-height') public columnVirtualHeight: Nullable<number> = null;
     @Input('selection-entries') public selectionEntries: PlainObjectOf<boolean> = {};

--- a/libs/cdk/virtual-table/src/table-builder.component.html
+++ b/libs/cdk/virtual-table/src/table-builder.component.html
@@ -42,7 +42,7 @@
     <div
         *ngIf="source?.length === 0 && filterable.filterValueExist"
         class="table-grid__root-empty-after-filter"
-        [innerHTML]="ngxEmptyContent?.nativeElement?.innerHTML | safe: 'html'"
+        [innerHTML]="ngxEmptyContent?.nativeElement?.innerHTML | safe : 'html'"
     ></div>
 
     <div

--- a/libs/cdk/virtual-table/src/table-builder.component.html
+++ b/libs/cdk/virtual-table/src/table-builder.component.html
@@ -42,7 +42,7 @@
     <div
         *ngIf="source?.length === 0 && filterable.filterValueExist"
         class="table-grid__root-empty-after-filter"
-        [innerHTML]="ngxEmptyContent?.nativeElement?.innerHTML | safe : 'html'"
+        [innerHTML]="ngxEmptyContent?.nativeElement?.innerHTML | safe: 'html'"
     ></div>
 
     <div
@@ -152,6 +152,7 @@
                             [context-menu]="contextMenuTemplate"
                             [enable-selection]="isEnableSelection"
                             [enable-filtering]="isEnableFiltering"
+                            [disable-deep-path]="disableDeepPath"
                             [client-row-height]="clientRowHeight"
                             [selection-entries]="selectionEntries"
                             [produce-disable-fn]="produceDisableFn"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Column headers used deep path pipe based on the presence of dot in it. It made impossible to have a header with dot and see the content of the column cells. 
Issue Number: N/A

## What is the new behavior?

Now user can disable deep path if they want to use headers with dots in the table.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
