### PR TITLE
fix: make table rerender when table keys change

### DIFF
--- a/libs/cdk/virtual-table/src/abstract-table-builder-api.directive.ts
+++ b/libs/cdk/virtual-table/src/abstract-table-builder-api.directive.ts
@@ -83,7 +83,7 @@ export abstract class AbstractTableBuilderApiDirective<T>
     private _headHeight: Nullable<number> = null;
     private _rowHeight: Nullable<number> = null;
     protected originalSource: Nullable<T[]> = null;
-    protected renderedCountKeys: Nullable<number> = null;
+    protected renderedKeys: string[] = [];
     protected isDragMoving: boolean = false;
     @Input() public height: Nullable<string | number> = null;
     @Input() public width: Nullable<string | number> = null;
@@ -430,8 +430,8 @@ export abstract class AbstractTableBuilderApiDirective<T>
      * @description: returns the number of keys in the model
      * @example: <table-builder [source]=[{ id: 1, name: 'hello' }, ...] /> a value of 2 will be returned
      */
-    protected getCountKeys(): number {
-        return Object.keys(this.firstItem).length;
+    protected getKeys(): string[] {
+        return Object.keys(this.firstItem);
     }
 
     /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Table does not rerender when number of keys remains the same though the keys itself change.

## What is the new behavior?

Table does rerender when keys change.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```
