### PR TITLE
fix: use object for data state type agument

### DIFF
--- a/libs/ngxs/decorators/src/named/named.ts
+++ b/libs/ngxs/decorators/src/named/named.ts
@@ -1,9 +1,9 @@
 import { ensureMethodArgsRegistry, MethodArgsRegistry } from '@angular-ru/ngxs/internals';
 import { NGXS_DATA_EXCEPTIONS } from '@angular-ru/ngxs/tokens';
-import { DataStateClass, StateArgumentDecorator } from '@angular-ru/ngxs/typings';
+import { StateArgumentDecorator } from '@angular-ru/ngxs/typings';
 
 export function Named(name: string): StateArgumentDecorator {
-    return (stateClass: DataStateClass, methodName: string | symbol, parameterIndex: number): void => {
+    return (stateClass: Record<any, any>, methodName: string | symbol, parameterIndex: number): void => {
         const key: string = name.trim();
 
         if (!key) {

--- a/libs/ngxs/decorators/src/payload/payload.ts
+++ b/libs/ngxs/decorators/src/payload/payload.ts
@@ -1,9 +1,9 @@
 import { ensureMethodArgsRegistry, MethodArgsRegistry } from '@angular-ru/ngxs/internals';
 import { NGXS_DATA_EXCEPTIONS } from '@angular-ru/ngxs/tokens';
-import { DataStateClass, StateArgumentDecorator } from '@angular-ru/ngxs/typings';
+import { StateArgumentDecorator } from '@angular-ru/ngxs/typings';
 
 export function Payload(name: string): StateArgumentDecorator {
-    return (stateClass: DataStateClass, methodName: string | symbol, parameterIndex: number): void => {
+    return (stateClass: Record<any, any>, methodName: string | symbol, parameterIndex: number): void => {
         const key: string = name.trim();
 
         if (!key) {

--- a/libs/ngxs/typings/src/common/data-state-class.ts
+++ b/libs/ngxs/typings/src/common/data-state-class.ts
@@ -13,7 +13,7 @@ export interface DataStateClass<T = any, U = any> extends StateClassInternal<T, 
 export type StateClassDecorator = (stateClass: DataStateClass) => void;
 
 export type StateArgumentDecorator = (
-    stateClass: Object,
+    stateClass: Record<any, any>,
     propertyKey: string | symbol,
     parameterIndex: number
 ) => void;

--- a/libs/ngxs/typings/src/common/data-state-class.ts
+++ b/libs/ngxs/typings/src/common/data-state-class.ts
@@ -13,7 +13,7 @@ export interface DataStateClass<T = any, U = any> extends StateClassInternal<T, 
 export type StateClassDecorator = (stateClass: DataStateClass) => void;
 
 export type StateArgumentDecorator = (
-    stateClass: DataStateClass,
+    stateClass: Object,
     propertyKey: string | symbol,
     parameterIndex: number
 ) => void;


### PR DESCRIPTION


## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)



## What is the current behavior?

The compilation is broken on Angular 16 
![image](https://github.com/Angular-RU/angular-ru-sdk/assets/5416207/490097ab-5a76-4f36-aa6d-d1ff4215fd00)

Issue Number: N/A

## What is the new behavior?

Since the update to angular 16 I have errors with the type of first argument of StateArgumentDecorator
With `Object` instead `DataStateClass` everything works fine.

## Does this PR introduce a breaking change?

-   [ ]  Yes
-   [x]  No



