### PR TITLE
fix: introduce Angular v20 compatibility by removing "InjectFlags" usage

### DIFF
--- a/libs/cdk/date/date-suggestion/date-suggestion.composer.ts
+++ b/libs/cdk/date/date-suggestion/date-suggestion.composer.ts
@@ -1,4 +1,4 @@
-import {Inject, Injectable, InjectFlags, Injector} from '@angular/core';
+import {Inject, Injectable, Injector} from '@angular/core';
 import {Nullable} from '@angular-ru/cdk/typings';
 import {isNil} from '@angular-ru/cdk/utils';
 
@@ -28,7 +28,7 @@ export class DateSuggestionComposer<StrategyKeys extends StrategyKey = StrategyK
                 ...(descriptor.providers ?? []),
             ],
             parent: this.injector,
-        }).get(descriptor.strategy, null, InjectFlags.Optional);
+        }).get(descriptor.strategy, null, {optional: true});
 
         if (isNil(strategy)) {
             throw new Error('This type of date suggestion is not supported');

--- a/libs/cdk/ivy/utils/injection-utils.ts
+++ b/libs/cdk/ivy/utils/injection-utils.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-redeclare */
-import {AbstractType, InjectionToken, Type} from '@angular/core';
+import {AbstractType, InjectionToken, InjectOptions, Type} from '@angular/core';
 import {
-    InjectFlags,
     ɵɵdirectiveInject as ivyDirectiveInject,
     ɵɵinject as ivyInject,
 } from '@angular/core';
@@ -10,16 +9,16 @@ import {Fn, Nullable} from '@angular-ru/cdk/typings';
 function wrapperForInject<T>(
     wrap: Fn,
     token: AbstractType<T> | InjectionToken<T> | Type<T>,
-    flags?: InjectFlags,
+    options?: InjectOptions,
 ): Nullable<T> {
-    if (InjectFlags.Optional) {
+    if (options?.optional) {
         try {
-            return wrap(token, flags!);
+            return wrap(token, options);
         } catch {
             return null;
         }
     } else {
-        return flags ? wrap(token, flags) : wrap(token);
+        return options ? wrap(token, options) : wrap(token);
     }
 }
 
@@ -31,14 +30,14 @@ export function directiveInject<T>(
 ): T;
 export function directiveInject<T>(
     token: AbstractType<T> | InjectionToken<T> | Type<T>,
-    flags: InjectFlags,
+    options: InjectOptions,
 ): Nullable<T>;
 
 export function directiveInject<T>(
     token: AbstractType<T> | InjectionToken<T> | Type<T>,
-    flags?: InjectFlags,
+    options?: InjectOptions,
 ): Nullable<T> {
-    return wrapperForInject(ivyDirectiveInject, token, flags);
+    return wrapperForInject(ivyDirectiveInject, token, options);
 }
 
 /**
@@ -47,12 +46,12 @@ export function directiveInject<T>(
 export function inject<T>(token: AbstractType<T> | InjectionToken<T> | Type<T>): T;
 export function inject<T>(
     token: AbstractType<T> | InjectionToken<T> | Type<T>,
-    flags: InjectFlags,
+    options: InjectOptions,
 ): Nullable<T>;
 
 export function inject<T>(
     token: AbstractType<T> | InjectionToken<T> | Type<T>,
-    flags?: InjectFlags,
+    options?: InjectOptions,
 ): Nullable<T> {
-    return wrapperForInject(ivyInject, token, flags);
+    return wrapperForInject(ivyInject, token, options);
 }

--- a/libs/cdk/tests/ivy/injection-utils.spec.ts
+++ b/libs/cdk/tests/ivy/injection-utils.spec.ts
@@ -1,4 +1,4 @@
-import {Component, Injectable, InjectFlags} from '@angular/core';
+import {Component, Injectable} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {directiveInject, inject} from '@angular-ru/cdk/ivy';
 import {Nullable} from '@angular-ru/cdk/typings';
@@ -68,7 +68,7 @@ describe('[TEST]: injection utils', () => {
                 public b: Nullable<B> = null;
 
                 constructor() {
-                    this.b = inject(B, InjectFlags.Optional);
+                    this.b = inject(B, {optional: true});
                 }
             }
 
@@ -92,7 +92,7 @@ describe('[TEST]: injection utils', () => {
                 public service: Nullable<Service>;
 
                 constructor() {
-                    this.service = directiveInject(Service, InjectFlags.Optional);
+                    this.service = directiveInject(Service, {optional: true});
                 }
             }
 

--- a/libs/ngxs/decorators/data-action/data-action.ts
+++ b/libs/ngxs/decorators/data-action/data-action.ts
@@ -1,4 +1,3 @@
-import {InjectFlags} from '@angular/core';
 import {$args} from '@angular-ru/cdk/function';
 import {Descriptor, PlainObjectOf} from '@angular-ru/cdk/typings';
 import {isNil, isNotNil, isTrue} from '@angular-ru/cdk/utils';
@@ -127,11 +126,8 @@ export function DataAction(options: RepositoryActionOptions = {}): MethodDecorat
 }
 
 function mergeConfig(options: RepositoryActionOptions): RepositoryActionOptions {
-    const globalConfig: NgxsDataConfig | undefined = NgxsDataInjector?.injector?.get(
-        NGXS_DATA_CONFIG,
-        undefined,
-        InjectFlags.Optional,
-    );
+    const globalConfig: NgxsDataConfig | null | undefined =
+        NgxsDataInjector?.injector?.get(NGXS_DATA_CONFIG, undefined, {optional: true});
     const mergedOptions: RepositoryActionOptions = {...REPOSITORY_ACTION_OPTIONS};
 
     if (


### PR DESCRIPTION
## What is the current behavior?

Angular `v20` build fails because of missing `InjectFlags` enum.

Issue Number: #1531

## What is the new behavior?

Works with Angular `v20`.