### PR TITLE
fix(ngxs): missing null check before accessing meta.version property

### DIFF
--- a/libs/ngxs/storage/utils/deserialize-by-storage-meta.ts
+++ b/libs/ngxs/storage/utils/deserialize-by-storage-meta.ts
@@ -34,7 +34,7 @@ export function deserializeByStorageMeta<T>(
     throw new InvalidStructureDataException(`"${value}" not an object`);
 }
 
-function versionIsInvalid<T>(meta: StorageMeta<T>): boolean {
+function versionIsInvalid<T>(meta?: StorageMeta<T> | null): boolean {
     if (!meta) {
         return true;
     }

--- a/libs/ngxs/storage/utils/deserialize-by-storage-meta.ts
+++ b/libs/ngxs/storage/utils/deserialize-by-storage-meta.ts
@@ -35,6 +35,10 @@ export function deserializeByStorageMeta<T>(
 }
 
 function versionIsInvalid<T>(meta: StorageMeta<T>): boolean {
+    if (!meta) {
+        return true;
+    }
+
     const version: number = parseFloat(meta.version?.toString() ?? '');
 
     return (


### PR DESCRIPTION
## Bug Fix: Missing null check in versionIsInvalid

### Problem
The `versionIsInvalid` function in `deserializeByStorageMeta` accesses `meta.version` without checking if `meta` is null or undefined. If storage returns null/undefined data, this causes a runtime crash with 'Cannot read property 'version' of null/undefined'.

### Solution
Added a defensive null check at the beginning of `versionIsInvalid` function that returns `true` (invalid) when `meta` is null or undefined, preventing the runtime crash.

### Changes
- Modified `versionIsInvalid` function in `libs/ngxs/storage/utils/deserialize-by-storage-meta.ts`
- Added `if (!meta) { return true; }` check before accessing `meta.version`

### Testing
This fix ensures that when storage returns null/undefined data, the function gracefully handles it by returning `true` (version is invalid) instead of crashing.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.